### PR TITLE
Add gemini-2.5-flash option

### DIFF
--- a/mistralocr_app.py
+++ b/mistralocr_app.py
@@ -1101,6 +1101,7 @@ def create_gradio_interface():
                             ("pixtral-12b-latest (Recommended)", "pixtral-12b-latest"),
                             ("gemini-2.0-flash (Recommended)", "gemini-2.0-flash"),
                             ("gemini-2.5-flash-preview-05-20", "gemini-2.5-flash-preview-05-20"),
+                            ("gemini-2.5-flash", "gemini-2.5-flash"),
                             ("gpt-4o-mini", "gpt-4o-mini"),
                             ("gpt-4o", "gpt-4o"),
                             ("gpt-4.1-nano (Not Recommended)", "gpt-4.1-nano"),
@@ -1120,6 +1121,7 @@ def create_gradio_interface():
                         choices=[
                             ("gemini-2.0-flash (Recommended)", "gemini-2.0-flash"),
                             ("gemini-2.5-flash-preview-05-20", "gemini-2.5-flash-preview-05-20"),
+                            ("gemini-2.5-flash", "gemini-2.5-flash"),
                             ("gemini-2.5-pro-exp-03-25", "gemini-2.5-pro-exp-03-25"),
                             ("gemini-2.0-flash-lite", "gemini-2.0-flash-lite"),
                             ("gpt-4o", "gpt-4o"), 


### PR DESCRIPTION
## Summary
- add gemini-2.5-flash to structure and translation model lists

## Testing
- `ruff check mistralocr_app.py | head -n 20`

------
https://chatgpt.com/codex/tasks/task_b_685fef328d4c832ebc053783fbc5da3b